### PR TITLE
fix: use MapNull instead of uninstantiated generic ObjectMap

### DIFF
--- a/dto/output/serviceStackTypeProfile.go
+++ b/dto/output/serviceStackTypeProfile.go
@@ -16,6 +16,6 @@ type ServiceStackTypeProfile struct {
 	Description       types.String      `json:"description"`
 	IsDefault         types.Bool        `json:"isDefault"`
 	CustomAutoscaling CustomAutoscaling `json:"customAutoscaling"`
-	Overrides         types.ObjectMap   `json:"overrides"`
+	Overrides         types.MapNull   `json:"overrides"`
 	Order             types.Int         `json:"order"`
 }


### PR DESCRIPTION
`types.ObjectMap[K, V any]` is an uninstantiated generic type and cannot be used as a concrete field type in structs. This causes the SDK to panic when marshaling/unmarshaling certain API responses that use `types.ObjectMap`.

Replaced with `types.MapNull[string, any]` which is the concrete instantiation that was intended.